### PR TITLE
loader.py: region alignment to support -O3

### DIFF
--- a/libsel4cp/Makefile
+++ b/libsel4cp/Makefile
@@ -12,7 +12,7 @@ $(error GCC_CPU must be specified)
 endif
 
 TOOLCHAIN := aarch64-none-elf-
-CFLAGS := -std=gnu11 -g3 -O3 -nostdlib -ffreestanding -mcpu=$(GCC_CPU) -Wall -Wno-maybe-uninitialized -Wno-unused-function -Werror -Iinclude -I$(SEL4_SDK)/include
+CFLAGS := -std=gnu11 -g3 -O3 -mgeneral-regs-only -nostdlib -ffreestanding -mcpu=$(GCC_CPU) -Wall -Wno-maybe-uninitialized -Wno-unused-function -Werror -Iinclude -I$(SEL4_SDK)/include
 
 LIBS := libsel4cp.a
 OBJS := main.o dbg.o


### PR DESCRIPTION
Compilation of loader.c with optimization flag -ftree-loop-vectorize (included in -O3) generates code which uses 128-bit q registers while copying regions from image to lower addresses.

To make source address "base + offset" multiple of 16, function 'write_image' now rounds up the offset and properly fills in gaps between regions if needed during image building.