### PR TITLE
Fix order of attributes and rights fields in Sel4PageMap invocation

### DIFF
--- a/tool/sel4coreplat/sel4.py
+++ b/tool/sel4coreplat/sel4.py
@@ -606,8 +606,8 @@ class Sel4PageMap(Sel4Invocation):
     page: int
     vspace: int
     vaddr: int
-    attr: int
     rights: int
+    attr: int
 
 
 @dataclass


### PR DESCRIPTION
The `seL4_ARM_Page_Map` invocation takes in the page attributes after the page rights. The seL4CP tool that creates the invocations has the correct order so it does not need to change, but because the invocation's fields in the wrong order, the actual invocations that were being generated were wrong.