### PR TITLE
Fix max ID checks on channels/IRQs

### DIFF
--- a/docs/manual.md
+++ b/docs/manual.md
@@ -466,7 +466,7 @@ The `map` element has the following attributes:
 The `irq` element has the following attributes:
 
 * `irq`: The hardware interrupt number.
-* `id`: The channel identifier.
+* `id`: The channel identifier. Must be at least 0 and less than 63.
 
 The `setvar` element has the following attributes:
 
@@ -493,7 +493,7 @@ The `channel` element has exactly two `end` children elements for specifying the
 The `end` element has the following attributes:
 
 * `pd`: Name of the protection domain for this end.
-* `id`: Channel identifier in the context of the named protection domain.
+* `id`: Channel identifier in the context of the named protection domain. Must be at least 0 and less than 63.
 
 The `id` is passed to the PD in the `notified` and `protected` entry points.
 The `id` should be passed to the `sel4cp_notify` and `sel4cp_ppcall` functions.

--- a/docs/manual.md
+++ b/docs/manual.md
@@ -199,7 +199,7 @@ In this case the channel identifier is effectively a proxy identifier for the ot
 So, to extend the prior example, **A** can indirectly refer to **B** via the channel identifier **37**.
 Similarly, **B** can refer to **A** via the channel identifier **42**.
 
-The system supports a maximum up 64 channels and interrupts per protection domain.
+The system supports a maximum of 63 channels and interrupts per protection domain.
 
 ### Protected procedure
 

--- a/tool/sel4coreplat/sysxml.py
+++ b/tool/sel4coreplat/sysxml.py
@@ -263,6 +263,10 @@ def xml2pd(pd_xml: ET.Element) -> ProtectionDomain:
                 _check_attrs(child, ("irq", "id"))
                 irq = int(checked_lookup(child, "irq"), base=0)
                 id_ = int(checked_lookup(child, "id"), base=0)
+                if id_ >= 63:
+                    raise ValueError("id must be < 63")
+                if id_ < 0:
+                    raise ValueError("id must be >= 0")
                 irqs.append(SysIrq(irq, id_))
             elif child.tag == "setvar":
                 _check_attrs(child, ("symbol", "region_paddr"))

--- a/tool/sel4coreplat/sysxml.py
+++ b/tool/sel4coreplat/sysxml.py
@@ -289,8 +289,8 @@ def xml2channel(ch_xml: ET.Element) -> Channel:
                 _check_attrs(ch_xml, ("pd", "id"))
                 pd = checked_lookup(child, "pd")
                 id_ = int(checked_lookup(child, "id"))
-                if id_ >= 64:
-                    raise ValueError("id must be < 64")
+                if id_ >= 63:
+                    raise ValueError("id must be < 63")
                 if id_ < 0:
                     raise ValueError("id must be >= 0")
                 ends.append((pd, id_))

--- a/tool/test/__init__.py
+++ b/tool/test/__init__.py
@@ -99,8 +99,8 @@ class ChannelParseTests(ExtendedTestCase):
     def test_missing_id(self):
         self._check_missing("ch_missing_id.xml", "id", "end")
 
-    def test_id_greater_than_63(self):
-        self._check_error("ch_id_greater_than_63.xml", "Error: id must be < 64 on element 'end'")
+    def test_id_greater_than_62(self):
+        self._check_error("ch_id_greater_than_62.xml", "Error: id must be < 63 on element 'end'")
 
     def test_id_less_than_0(self):
         self._check_error("ch_id_less_than_0.xml", "Error: id must be >= 0 on element 'end'")

--- a/tool/test/__init__.py
+++ b/tool/test/__init__.py
@@ -91,6 +91,12 @@ class ProtectionDomainParseTests(ExtendedTestCase):
     def test_budget_gt_period(self):
         self._check_error("pd_budget_gt_period.xml", "Error: budget (1000) must be less than, or equal to, period (100) on element 'protection_domain':")
 
+    def test_irq_greater_than_62(self):
+        self._check_error("irq_id_greater_than_62.xml", "Error: id must be < 63 on element 'irq'")
+
+    def test_irq_less_than_0(self):
+        self._check_error("irq_id_less_than_0.xml", "Error: id must be >= 0 on element 'irq'")
+
 
 class ChannelParseTests(ExtendedTestCase):
     def test_missing_pd(self):

--- a/tool/test/ch_id_greater_than_62.xml
+++ b/tool/test/ch_id_greater_than_62.xml
@@ -12,7 +12,7 @@
         <program_image path="test" />
     </protection_domain>
     <channel>
-        <end pd="test1" id="64"/>
+        <end pd="test1" id="63"/>
         <end pd="test2" id="5"/>
     </channel>
 </system>

--- a/tool/test/irq_id_greater_than_62.xml
+++ b/tool/test/irq_id_greater_than_62.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Copyright 2023, UNSW
+
+ SPDX-License-Identifier: BSD-2-Clause
+-->
+<system>
+    <protection_domain name="test1">
+        <program_image path="test" />
+        <irq irq="1" id="63" />
+    </protection_domain>
+</system>

--- a/tool/test/irq_id_less_than_0.xml
+++ b/tool/test/irq_id_less_than_0.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Copyright 2023, UNSW
+
+ SPDX-License-Identifier: BSD-2-Clause
+-->
+<system>
+    <protection_domain name="test1">
+        <program_image path="test" />
+        <irq irq="1" id="-1" />
+    </protection_domain>
+</system>


### PR DESCRIPTION
This PR does two things.

1. Fixes the max ID for a channel end to be 62 instead of 63. This is because the last bit of the badge is used to distinguish on whether we have received an PPC or a notification. Having the max ID as 63 will mean this bit is overwritten and so notifying a channel with an ID of 63 will instead be delivered as a PPC.
2. Applies the same fix to IRQs and adds tests like for channel IDs.
3. Makes a note of the valid channel/IRQ IDs in the manual.