### PR TITLE
Add error checking for write-only memory region mappings

### DIFF
--- a/docs/manual.md
+++ b/docs/manual.md
@@ -463,7 +463,7 @@ The `map` element has the following attributes:
 
 * `mr`: Identifies the memory region to map.
 * `vaddr`: Identifies the virtual address at which to map the memory region.
-* `perms`: Identifies the permissions with which to map the memory region. Can be a combination of `r` (read), `w` (write), and `x` (eXecute).
+* `perms`: Identifies the permissions with which to map the memory region. Can be a combination of `r` (read), `w` (write), and `x` (eXecute), with the exception of a write-only mapping (just `w`).
 * `cached`: Determines if mapped with caching enabled or disabled. Defaults to `true`.
 * `setvar_vaddr`: Specifies a symbol in the program image. This symbol will be rewritten with the virtual address of the memory region.
 

--- a/tool/sel4coreplat/sysxml.py
+++ b/tool/sel4coreplat/sysxml.py
@@ -255,6 +255,10 @@ def xml2pd(pd_xml: ET.Element) -> ProtectionDomain:
                 mr = checked_lookup(child, "mr")
                 vaddr = int(checked_lookup(child, "vaddr"), base=0)
                 perms = child.attrib.get("perms", "rw")
+                # On all architectures, the kernel does not allow write-only mappings
+                if perms == "w":
+                    raise ValueError("perms must not be 'w', write-only mappings are not allowed")
+
                 cached = str_to_bool(child.attrib.get("cached", "true"))
                 maps.append(SysMap(mr, vaddr, perms, cached, child))
 

--- a/tool/test/__init__.py
+++ b/tool/test/__init__.py
@@ -97,6 +97,9 @@ class ProtectionDomainParseTests(ExtendedTestCase):
     def test_irq_less_than_0(self):
         self._check_error("irq_id_less_than_0.xml", "Error: id must be >= 0 on element 'irq'")
 
+    def test_write_only_mr(self):
+        self._check_error("pd_write_only_mr.xml", f"Error: perms must not be 'w', write-only mappings are not allowed on element 'map':")
+
 
 class ChannelParseTests(ExtendedTestCase):
     def test_missing_pd(self):

--- a/tool/test/pd_write_only_mr.xml
+++ b/tool/test/pd_write_only_mr.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Copyright 2023, UNSW
+
+ SPDX-License-Identifier: BSD-2-Clause
+-->
+<system>
+    <memory_region name="test_mr" size="0x1_000" />
+    <protection_domain name="test">
+        <program_image path="test" />
+        <map mr="test_mr" vaddr="0x3_000_000" perms="w" />
+    </protection_domain>
+</system>


### PR DESCRIPTION
On all architectures that seL4 currently supports, write-only mappings are not allowed. It is preferable to catch these at build-time rather than having an error at run-time.