### PR TITLE
Temporarily disable i.MX8MM-EVK support

### DIFF
--- a/build_sdk.py
+++ b/build_sdk.py
@@ -73,19 +73,19 @@ SUPPORTED_BOARDS = (
             "hello": Path("example/zcu102/hello")
         }
     ),
-    BoardInfo(
-        name="imx8mm",
-        gcc_cpu="cortex-a53",
-        loader_link_address=0x41000000,
-        kernel_options = {
-            "KernelPlatform": "imx8mm-evk",
-            "KernelIsMCS": True,
-            "KernelArmExportPCNTUser": True,
-        },
-        examples = {
-            "passive_server": Path("example/imx8mm/passive_server")
-        }
-    )
+    # BoardInfo(
+    #     name="imx8mm",
+    #     gcc_cpu="cortex-a53",
+    #     loader_link_address=0x41000000,
+    #     kernel_options = {
+    #         "KernelPlatform": "imx8mm-evk",
+    #         "KernelIsMCS": True,
+    #         "KernelArmExportPCNTUser": True,
+    #     },
+    #     examples = {
+    #         "passive_server": Path("example/imx8mm/passive_server")
+    #     }
+    # )
 )
 
 SUPPORTED_CONFIGS = (


### PR DESCRIPTION
The standalone seL4 kernel ELF does not successfully build for the i.MX8MM-EVK. This is fixed in a later version of seL4. In the interest of having the SDK build, we temporarily disable building the SDK for this platform.

I do not have access to the seL4 repository that the SDK uses and hence cannot fix the source of the issue at this moment.