### PR TITLE
Make use of pyenv consistent in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Testing has been performed using commit `92f0f3ab28f00c97851512216c855f4180534a6
 
 ## Building the SDK
 
-    $ ./env/bin/python build_sdk.py --sel4=<path to sel4>
+    $ ./pyenv/bin/python build_sdk.py --sel4=<path to sel4>
 
 ## Using the SDK
 


### PR DESCRIPTION
All the other commands use `./pyenv` instead of `./env` so when copy+pasting the commands to run it breaks the flow,